### PR TITLE
NIFI-14371 add support for DisallowRunOnce annotation

### DIFF
--- a/src/main/java/org/apache/nifi/annotation/behavior/DisallowRunOnce.java
+++ b/src/main/java/org/apache/nifi/annotation/behavior/DisallowRunOnce.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.annotation.behavior;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * <p>
+ * Marker annotation a {@link org.apache.nifi.processor.Processor Processor}
+ * implementation can use to indicate that the Processor is not designed in
+ * such a way that the 'Run Once' capability would function.
+ * </p>
+ *
+ * <p>
+ * Some processors need many execution cycles to perform any meaningful work
+ * and as such the user triggering a 'Run Once' execution will likely result
+ * in no response or outcome at all.
+ * </p>
+ */
+@Documented
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+public @interface DisallowRunOnce {
+
+    /**
+     * An optional explanation for why run once is not supported
+     * @return explanation string that may end up being shared with users
+     */
+    String explanation();
+
+}


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0 -->

# Summary

[NIFI-14371](https://issues.apache.org/jira/browse/NIFI-14371) Add support for extension developers to indicate that a given extension does not support the run once capability.

[NIP-5](https://issues.apache.org/jira/browse/NIP-5) has been approved.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes
