### PR TITLE
NIFI-14718 - Bump Maven to 3.9.10, JUnit to 5.13.2, Mockito to 5.18.0 and others

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ nb-configuration.xml
 .DS_Store
 .metadata
 .recommenders
+.checkstyle
 *.iml
 *.iws
 *.ipr

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -16,4 +16,4 @@
 # under the License.
 wrapperVersion=3.3.2
 distributionType=only-script
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.10/apache-maven-3.9.10-bin.zip

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.apache</groupId>
         <artifactId>apache</artifactId>
-        <version>33</version>
+        <version>35</version>
         <relativePath/>
     </parent>
 
@@ -75,15 +75,16 @@
         <maven.compiler.release>21</maven.compiler.release>
         <maven.compiler.showDeprecation>true</maven.compiler.showDeprecation>
         <minimalJavaBuildVersion>21</minimalJavaBuildVersion>
-        <minimalMavenBuildVersion>3.9.9</minimalMavenBuildVersion>
+        <minimalMavenBuildVersion>3.9.10</minimalMavenBuildVersion>
 
-        <checkstyle.version>10.18.1</checkstyle.version>
-        <junit-bom.version>5.11.0</junit-bom.version>
-        <jacoco.version>0.8.12</jacoco.version>
-        <maven-pmd-plugin.version>3.25.0</maven-pmd-plugin.version>
-        <mockito.version>5.13.0</mockito.version>
-        <pmd.version>7.10.0</pmd.version>
-        <swagger-annotations.version>2.2.23</swagger-annotations.version>
+        <checkstyle.version>10.26.1</checkstyle.version>
+        <junit-bom.version>5.13.2</junit-bom.version>
+        <jacoco.version>0.8.13</jacoco.version>
+        <maven-pmd-plugin.version>3.27.0</maven-pmd-plugin.version>
+        <version.maven-checkstyle-plugin>3.6.0</version.maven-checkstyle-plugin>
+        <mockito.version>5.18.0</mockito.version>
+        <pmd.version>7.14.0</pmd.version>
+        <swagger-annotations.version>2.2.34</swagger-annotations.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
# Summary

[NIFI-14718](https://issues.apache.org/jira/browse/NIFI-14718) - Bump Maven to 3.9.10, JUnit to 5.13.2, Mockito to 5.18.0 and others

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes
