### PR TITLE
NIFI-14850 - Fix OpenAPI Enum inconsistencies

### DIFF
--- a/src/main/java/org/apache/nifi/flow/VersionedConnection.java
+++ b/src/main/java/org/apache/nifi/flow/VersionedConnection.java
@@ -17,10 +17,10 @@
 
 package org.apache.nifi.flow;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.List;
 import java.util.Set;
-
-import io.swagger.v3.oas.annotations.media.Schema;
 
 public class VersionedConnection extends VersionedComponent {
     private ConnectableComponent source;
@@ -136,8 +136,8 @@ public class VersionedConnection extends VersionedComponent {
         this.prioritizers = prioritizers;
     }
 
-    @Schema(description = "The Strategy to use for load balancing data across the cluster, or null, if no Load Balance Strategy has been specified.",
-            allowableValues = "DO_NOT_LOAD_BALANCE, PARTITION_BY_ATTRIBUTE, ROUND_ROBIN, SINGLE_NODE")
+    @Schema(description = "The Strategy to use for load balancing data across the cluster, or null, if no Load Balance Strategy has been specified. "
+            + "Possible returned values: DO_NOT_LOAD_BALANCE, PARTITION_BY_ATTRIBUTE, ROUND_ROBIN, SINGLE_NODE. See LoadBalanceStrategy.class for more details.")
     public String getLoadBalanceStrategy() {
         return loadBalanceStrategy;
     }
@@ -157,8 +157,8 @@ public class VersionedConnection extends VersionedComponent {
         this.partitioningAttribute = partitioningAttribute;
     }
 
-    @Schema(description = "Whether or not compression should be used when transferring FlowFiles between nodes",
-            allowableValues = "DO_NOT_COMPRESS, COMPRESS_ATTRIBUTES_ONLY, COMPRESS_ATTRIBUTES_AND_CONTENT")
+    @Schema(description = "Whether or not compression should be used when transferring FlowFiles between nodes "
+            + "Possible returned values: DO_NOT_COMPRESS, COMPRESS_ATTRIBUTES_ONLY, COMPRESS_ATTRIBUTES_AND_CONTENT. See LoadBalanceCompression.class for more details.")
     public String getLoadBalanceCompression() {
         return loadBalanceCompression;
     }

--- a/src/main/java/org/apache/nifi/flow/VersionedProcessor.java
+++ b/src/main/java/org/apache/nifi/flow/VersionedProcessor.java
@@ -178,8 +178,8 @@ public class VersionedProcessor extends VersionedConfigurableExtension {
     }
 
     @Schema(
-            description = "Determines whether the FlowFile should be penalized or the processor should be yielded between retries.",
-            allowableValues = "PENALIZE_FLOWFILE, YIELD_PROCESSOR"
+            description = "Determines whether the FlowFile should be penalized or the processor should be yielded between retries. "
+                    + "Possible returned values: PENALIZE_FLOWFILE, YIELD_PROCESSOR."
     )
     public String getBackoffMechanism() {
         return backoffMechanism;

--- a/src/main/java/org/apache/nifi/flow/VersionedRemoteProcessGroup.java
+++ b/src/main/java/org/apache/nifi/flow/VersionedRemoteProcessGroup.java
@@ -70,7 +70,7 @@ public class VersionedRemoteProcessGroup extends VersionedComponent {
         this.yieldDuration = yieldDuration;
     }
 
-    @Schema(description = "The Transport Protocol that is used for Site-to-Site communications", allowableValues = "RAW, HTTP")
+    @Schema(description = "The Transport Protocol that is used for Site-to-Site communications. Possible returned values: RAW, HTTP.")
     public String getTransportProtocol() {
         return transportProtocol;
     }


### PR DESCRIPTION
# Summary

NIFI-14850 - Fix OpenAPI Enum inconsistencies

`allowableValues` should not be used for `getX` methods

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes
