### PR TITLE
NIFI-15842 Guard against null fullyQualifiedParameterNames in fetchParameters

### DIFF
--- a/src/main/java/org/apache/nifi/parameter/ParameterProvider.java
+++ b/src/main/java/org/apache/nifi/parameter/ParameterProvider.java
@@ -148,7 +148,7 @@ public interface ParameterProvider extends ConfigurableComponent {
             final String name = context.getName();
             final String prefix = name + "." + group.getGroupName() + ".";
             for (final String fullyQualifiedParameterName : fullyQualifiedParameterNames) {
-                if (fullyQualifiedParameterName.startsWith(prefix)) {
+                if (fullyQualifiedParameterName != null && fullyQualifiedParameterName.startsWith(prefix)) {
                     final String secretName = fullyQualifiedParameterName.substring(prefix.length());
                     desiredParameterNames.add(secretName);
                 }


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0 -->

# Summary

[NIFI-15842](https://issues.apache.org/jira/browse/NIFI-15842)

The default fetchParameters(context, list) implementation iterates the fully qualified parameter names and calls startsWith() on each. Add a null check to skip null entries, preventing NPE if callers pass a list containing nulls.

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes
