### PR TITLE
NIFI-15982 Corrected StandardResourceReferenceFactory so it can now disambiguate between a file path and a single line Java comment.

### DIFF
--- a/src/main/java/org/apache/nifi/components/resource/StandardResourceReferenceFactory.java
+++ b/src/main/java/org/apache/nifi/components/resource/StandardResourceReferenceFactory.java
@@ -92,13 +92,15 @@ public class StandardResourceReferenceFactory implements ResourceReferenceFactor
         if (fileAllowed && textAllowed) {
             // We have to make a determination whether this is a file or text. Eventually, it will be best if the user tells us explicitly.
             // For now, we will make a determination based on a couple of simple rules.
-            final File file = new File(trimmed);
-            if ((!trimmed.startsWith("//") && file.isAbsolute()) || file.exists()) {
-                return new FileResourceReference(file);
-            }
+            if (!trimmed.startsWith("//")) {
+                final File file = new File(trimmed);
+                if (file.isAbsolute() || file.exists()) {
+                    return new FileResourceReference(file);
+                }
 
-            if (trimmed.startsWith("./") || trimmed.startsWith(".\\")) {
-                return new FileResourceReference(file);
+                if (trimmed.startsWith("./") || trimmed.startsWith(".\\")) {
+                    return new FileResourceReference(file);
+                }
             }
 
             return new Utf8TextResource(value); // Use explicit value, not trimmed value, as the white space may be important for textual content.

--- a/src/main/java/org/apache/nifi/components/resource/StandardResourceReferenceFactory.java
+++ b/src/main/java/org/apache/nifi/components/resource/StandardResourceReferenceFactory.java
@@ -93,7 +93,7 @@ public class StandardResourceReferenceFactory implements ResourceReferenceFactor
             // We have to make a determination whether this is a file or text. Eventually, it will be best if the user tells us explicitly.
             // For now, we will make a determination based on a couple of simple rules.
             final File file = new File(trimmed);
-            if (file.isAbsolute() || file.exists()) {
+            if ((!trimmed.startsWith("//") && file.isAbsolute()) || file.exists()) {
                 return new FileResourceReference(file);
             }
 

--- a/src/test/java/org/apache/nifi/components/resource/TestStandardResourceReferenceFactory.java
+++ b/src/test/java/org/apache/nifi/components/resource/TestStandardResourceReferenceFactory.java
@@ -22,8 +22,10 @@ import org.junit.jupiter.api.Test;
 import java.io.File;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -67,6 +69,7 @@ public class TestStandardResourceReferenceFactory {
 
         assertEmptyResourceReferences(resourceReferences);
     }
+
     @Test
     public void testCreateResourceReferencesWhenResourceDefinitionIsNull() {
         String value = "/dir1/test1.jar";
@@ -75,6 +78,24 @@ public class TestStandardResourceReferenceFactory {
         ResourceReferences resourceReferences = subject.createResourceReferences(value, resourceDefinition);
 
         assertEmptyResourceReferences(resourceReferences);
+    }
+
+    @Test
+    public void testDisambiguationBetweenTextAndFile() {
+        final String transformWithSingleLineComment = """
+                // This is a single line comment in JSLT
+                {
+                "id": .userId,
+                "name": .firstName
+                }
+                """;
+
+        final String trimmed = transformWithSingleLineComment.trim();
+        final ResourceDefinition resourceDefinition =
+                new StandardResourceDefinition(ResourceCardinality.SINGLE, Set.of(ResourceType.FILE, ResourceType.TEXT));
+        final ResourceReference resourceReference = subject.createResourceReference(trimmed, resourceDefinition);
+
+        assertInstanceOf(Utf8TextResource.class, resourceReference);
     }
 
     private StandardResourceDefinition createResourceDefinition() {

--- a/src/test/java/org/apache/nifi/components/resource/TestStandardResourceReferenceFactory.java
+++ b/src/test/java/org/apache/nifi/components/resource/TestStandardResourceReferenceFactory.java
@@ -90,10 +90,9 @@ public class TestStandardResourceReferenceFactory {
                 }
                 """;
 
-        final String trimmed = transformWithSingleLineComment.trim();
         final ResourceDefinition resourceDefinition =
                 new StandardResourceDefinition(ResourceCardinality.SINGLE, Set.of(ResourceType.FILE, ResourceType.TEXT));
-        final ResourceReference resourceReference = subject.createResourceReference(trimmed, resourceDefinition);
+        final ResourceReference resourceReference = subject.createResourceReference(transformWithSingleLineComment, resourceDefinition);
 
         assertInstanceOf(Utf8TextResource.class, resourceReference);
     }


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0 -->

# Summary

[NIFI-15982](https://issues.apache.org/jira/browse/NIFI-15982)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes
