### PR TITLE
NIFI-15979 Add connectorAttributes to ConnectorStatus

### DIFF
--- a/src/main/java/org/apache/nifi/controller/status/ConnectorStatus.java
+++ b/src/main/java/org/apache/nifi/controller/status/ConnectorStatus.java
@@ -16,6 +16,10 @@
  */
 package org.apache.nifi.controller.status;
 
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 /**
  * The status of a Connector, including the status of its managed root Process Group.
  *
@@ -36,6 +40,7 @@ public class ConnectorStatus implements Cloneable {
     private String id;
     private String name;
     private ProcessGroupStatus rootGroupStatus;
+    private Map<String, String> connectorAttributes = Map.of();
 
     /**
      * @return the identifier of the Connector
@@ -71,12 +76,27 @@ public class ConnectorStatus implements Cloneable {
         this.rootGroupStatus = rootGroupStatus;
     }
 
+    /**
+     * @return an immutable map of Connector-level attributes (for example, the Connector identifier, name, component
+     *         type, and bundle coordinate, along with any provider-supplied attributes). These describe the Connector
+     *         as a whole and are intended to be applied to logs and metrics emitted for its managed flow. Never
+     *         {@code null}.
+     */
+    public Map<String, String> getConnectorAttributes() {
+        return Collections.unmodifiableMap(connectorAttributes);
+    }
+
+    public void setConnectorAttributes(final Map<String, String> connectorAttributes) {
+        this.connectorAttributes = connectorAttributes == null ? Map.of() : new LinkedHashMap<>(connectorAttributes);
+    }
+
     @Override
     public ConnectorStatus clone() {
         final ConnectorStatus clonedObj = new ConnectorStatus();
         clonedObj.id = id;
         clonedObj.name = name;
         clonedObj.rootGroupStatus = rootGroupStatus == null ? null : rootGroupStatus.clone();
+        clonedObj.connectorAttributes = new LinkedHashMap<>(connectorAttributes);
         return clonedObj;
     }
 
@@ -85,6 +105,7 @@ public class ConnectorStatus implements Cloneable {
         return "ConnectorStatus [id=" + id
                 + ", name=" + name
                 + ", rootGroupStatus=" + rootGroupStatus
+                + ", connectorAttributes=" + connectorAttributes
                 + "]";
     }
 }

--- a/src/test/java/org/apache/nifi/controller/status/ConnectorStatusTest.java
+++ b/src/test/java/org/apache/nifi/controller/status/ConnectorStatusTest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.controller.status;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ConnectorStatusTest {
+
+    @Test
+    void connectorAttributesDefaultToEmptyAndAreNeverNull() {
+        final ConnectorStatus status = new ConnectorStatus();
+        assertNotNull(status.getConnectorAttributes());
+        assertTrue(status.getConnectorAttributes().isEmpty());
+
+        status.setConnectorAttributes(null);
+        assertNotNull(status.getConnectorAttributes());
+        assertTrue(status.getConnectorAttributes().isEmpty());
+    }
+
+    @Test
+    void setConnectorAttributesStoresDefensiveCopy() {
+        final ConnectorStatus status = new ConnectorStatus();
+        final Map<String, String> source = new HashMap<>();
+        source.put("connectorId", "id-1");
+        status.setConnectorAttributes(source);
+
+        // Mutating the source after the call must not affect the stored attributes.
+        source.put("connectorName", "added-after");
+
+        assertEquals(Map.of("connectorId", "id-1"), status.getConnectorAttributes());
+    }
+
+    @Test
+    void getConnectorAttributesReturnsImmutableView() {
+        final ConnectorStatus status = new ConnectorStatus();
+        status.setConnectorAttributes(Map.of("connectorId", "id-1"));
+        assertThrows(UnsupportedOperationException.class, () -> status.getConnectorAttributes().put("connectorName", "x"));
+    }
+
+    @Test
+    void cloneCopiesConnectorAttributesIndependently() {
+        final ConnectorStatus status = new ConnectorStatus();
+        final Map<String, String> attributes = new HashMap<>();
+        attributes.put("connectorId", "id-1");
+        attributes.put("connectorDefinitionId", "def-1");
+        status.setConnectorAttributes(attributes);
+
+        final ConnectorStatus clone = status.clone();
+        assertEquals(status.getConnectorAttributes(), clone.getConnectorAttributes());
+
+        // Mutating the original's attributes must not affect the clone.
+        status.setConnectorAttributes(Map.of("connectorId", "id-2"));
+        assertEquals("id-1", clone.getConnectorAttributes().get("connectorId"));
+        assertEquals("def-1", clone.getConnectorAttributes().get("connectorDefinitionId"));
+    }
+}


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0 -->

# Summary

[NIFI-15979](https://issues.apache.org/jira/browse/NIFI-00000)

Carry a `Map<String,String>` of Connector-level attributes (component, bundle coordinate, and ConnectorConfigurationProvider-supplied attributes) on `ConnectorStatus` so reporting consumers can enrich Connector-managed metrics.

This is a follow-up PR to #89 and is covered by the enhancements proposed (and approved) in [NIP-30](https://issues.apache.org/jira/browse/NIP-30).

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [x] Pull Request based on current revision of the `main` branch
- [x] Pull Request refers to a feature branch with one commit containing changes
