### PR TITLE
NIFI-16022 Fixed another StandardResourceReferenceFactory disambiguation for File path and comment prefix

### DIFF
--- a/src/main/java/org/apache/nifi/components/resource/StandardResourceReferenceFactory.java
+++ b/src/main/java/org/apache/nifi/components/resource/StandardResourceReferenceFactory.java
@@ -92,7 +92,7 @@ public class StandardResourceReferenceFactory implements ResourceReferenceFactor
         if (fileAllowed && textAllowed) {
             // We have to make a determination whether this is a file or text. Eventually, it will be best if the user tells us explicitly.
             // For now, we will make a determination based on a couple of simple rules.
-            if (!trimmed.startsWith("//")) {
+            if (!trimmed.startsWith("//") && !trimmed.startsWith("/*")) {
                 final File file = new File(trimmed);
                 if (file.isAbsolute() || file.exists()) {
                     return new FileResourceReference(file);

--- a/src/test/java/org/apache/nifi/components/resource/TestStandardResourceReferenceFactory.java
+++ b/src/test/java/org/apache/nifi/components/resource/TestStandardResourceReferenceFactory.java
@@ -18,11 +18,15 @@
 package org.apache.nifi.components.resource;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.File;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -80,8 +84,17 @@ public class TestStandardResourceReferenceFactory {
         assertEmptyResourceReferences(resourceReferences);
     }
 
-    @Test
-    public void testDisambiguationBetweenTextAndFile() {
+    @ParameterizedTest
+    @MethodSource("disambiguationBetweenTextAndFileArgs")
+    public void testDisambiguationBetweenTextAndFile(String text) {
+        final ResourceDefinition resourceDefinition =
+                new StandardResourceDefinition(ResourceCardinality.SINGLE, Set.of(ResourceType.FILE, ResourceType.TEXT));
+        final ResourceReference resourceReference = subject.createResourceReference(text, resourceDefinition);
+
+        assertInstanceOf(Utf8TextResource.class, resourceReference);
+    }
+
+    private static Stream<Arguments> disambiguationBetweenTextAndFileArgs() {
         final String transformWithSingleLineComment = """
                 // This is a single line comment in JSLT
                 {
@@ -90,11 +103,24 @@ public class TestStandardResourceReferenceFactory {
                 }
                 """;
 
-        final ResourceDefinition resourceDefinition =
-                new StandardResourceDefinition(ResourceCardinality.SINGLE, Set.of(ResourceType.FILE, ResourceType.TEXT));
-        final ResourceReference resourceReference = subject.createResourceReference(transformWithSingleLineComment, resourceDefinition);
+        final String transformWithMultiLineComment = """
+            /*
+                This is a multi-line Java comment in a JOLT spec.
+            */
+            [
+              {
+                "operation": "shift",
+                "spec": {
+                  "*": "&"
+                }
+              }
+            ]
+        """;
 
-        assertInstanceOf(Utf8TextResource.class, resourceReference);
+        return Stream.of(
+                Arguments.argumentSet("Leading single line Java comment", transformWithSingleLineComment),
+                Arguments.argumentSet("Leading multi-line Java comment", transformWithMultiLineComment)
+        );
     }
 
     private StandardResourceDefinition createResourceDefinition() {


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0 -->

# Summary

[NIFI-16022](https://issues.apache.org/jira/browse/NIFI-16022)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [x] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [x] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [x] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes
