### PR TITLE
NIFI-16033 Add AGENTS.md and SECURITY.md security-model discoverability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,15 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Agent Guide for Apache NiFi
+
+This file is read by automated agents (security scanners, code
+analyzers, AI assistants) operating on this repository.
+
+## Security
+
+Security model: [SECURITY.md](./SECURITY.md)
+
+Agents that scan this repository should consult `SECURITY.md` and the
+threat model it links before reporting issues.
+
+The project security model is published at https://nifi.apache.org/documentation/security/#security-model linked in SECURITY.md.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,36 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Security Policy
+
+## Reporting a Vulnerability
+
+Apache NiFi welcomes the responsible reporting of security vulnerabilities.
+The NiFi team believes that working with skilled security researchers across the globe is crucial in identifying weaknesses in any technology.
+If you believe you've found a security issue in our product or service, we encourage you to notify us.
+We will work with you to resolve the issue promptly.
+
+## Disclosure Policy
+
+* Let us know as soon as possible upon discovery of a potential security issue, and we'll make every effort to quickly resolve the issue.
+* Provide us a reasonable amount of time to resolve the issue before any disclosure to the public or a third-party.
+* Make a good faith effort to avoid privacy violations, destruction of data, and interruption or degradation of our service. Only interact with accounts you own or with explicit permission of the account holder.
+
+## Exclusions
+
+While researching, please refrain from:
+
+- Denial of service 
+- Spamming
+- Social engineering (including phishing) of Apache NiFi staff or contractors
+- Any physical attempts against Apache NiFi property or data centers
+
+## Reporting Methods
+
+- NiFi Security Mailing List: [security@nifi.apache.org](mailto:security@nifi.apache.org)
+  - Members of the [Project Management Committee](https://nifi.apache.org/people.html) monitor this private mailing list and respond to disclosures
+
+## Threat Model
+
+What the project treats as in scope and out of scope, the security
+properties it provides and disclaims, the adversary model, and how
+findings are triaged are documented in the project [Security Model](https://nifi.apache.org/documentation/security/#security-model).


### PR DESCRIPTION
**This is a proposal for the NiFi PMC to review — please correct, reject, or discuss as needed.**

This wires the conventional `AGENTS.md -> SECURITY.md -> security model` discoverability chain so an automated security-scan agent can mechanically locate NiFi's existing published security model (https://nifi.apache.org/documentation/security/#security-model).

- Adds `AGENTS.md` with a Security section pointing at `SECURITY.md`.
- Adds `SECURITY.md` with the ASF reporting pointer and a "Threat Model" link to the published security-model page.

No security-model *content* is authored here — it points at the model NiFi already maintains. Context: the ASF Security team is preparing the project for an automated agentic security scan we're piloting; such scans refuse to run unless the model is reachable via this chain. Wording/placement tweaks welcome.

Generated-by: Claude Opus 4.8 (1M context)
